### PR TITLE
Cleaning up testing

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,6 +6,8 @@ name: Clippy
   push:
     paths-ignore:
       - docs/**
+      - static/**
+      - plugins/**
 
 env:
   SCCACHE_GHA_ENABLED: "true"
@@ -23,6 +25,15 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.5
         with:
           version: "v0.4.2"
-      - name: "Run clippy (ignores errors, this is just a check)"
+      - name: "Run clippy"
         run: cargo clippy
-        continue-on-error: true
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.5
+        with:
+          version: "v0.4.2"
+      - name: "Run fmt"
+        run: cargo fmt

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -4,6 +4,8 @@ name: Rust Testing
   push:
     paths-ignore:
       - docs/**
+      - static/**
+      - plugins/**
 env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
@@ -17,16 +19,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.5
-        with:
-          version: "v0.5.4"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.5
-        with:
-          version: "v0.4.2"
       - name: Install typical dependencies
         run: |
           sudo apt-get update && \
@@ -34,11 +30,8 @@ jobs:
             libssl-dev
       - name: "Run cargo test"
         run: cargo test
-      - name: "Run cargo clippy"
-        run: cargo clippy
       - name: "Build the workspace"
         run: cargo build --workspace
-
       - name: "Cargo coverage"
         run: |
           cargo install cargo-tarpaulin


### PR DESCRIPTION
* fix(ci): ignoring some non-rust paths
* fix(ci): run `cargo clippy` and `cargo fmt` in CI with proper results, don't double-install sccache