### PR TITLE
Config things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tarpaulin-report.html
 config.json
 maremma.json
 maremma.sqlite
+*.sqlite.backup
 
 # ignore all the other plugins files
 plugins/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,7 +2124,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "maremma"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "askama",
  "askama_axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maremma"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 

--- a/maremma.schema.json
+++ b/maremma.schema.json
@@ -55,10 +55,8 @@
     },
     "services": {
       "description": "Service configuration",
-      "type": [
-        "object",
-        "null"
-      ],
+      "default": {},
+      "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/Service"
       }

--- a/maremma.schema.json
+++ b/maremma.schema.json
@@ -194,8 +194,8 @@
       ],
       "properties": {
         "id": {
-          "description": "The internal ID of the service",
-          "default": "0f8f85ea-785d-4a2d-aa09-5f0c4794a9d8",
+          "description": "The internal ID of the service, regenerated internally if not provided",
+          "default": "00000000-0000-0000-0000-000000000000",
           "type": "string",
           "format": "uuid"
         },

--- a/scripts/update_schema.sh
+++ b/scripts/update_schema.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCHEMA_TEMP_DIR=$(mktemp -d)
+
+NEWFILE="$SCHEMA_TEMP_DIR/maremma.schema.json"
+OLDFILE="./maremma.schema.json"
+cargo run -- export-config-schema > "${NEWFILE}"
+
+if [ ! -f "${OLDFILE}" ]; then
+    echo "No old schema file found, creating a new one"
+    mv "${NEWFILE}" "${OLDFILE}"
+    rm -rf "${SCHEMA_TEMP_DIR}"
+    exit 0
+fi
+
+DIFFSTR="$(diff "${OLDFILE}" "${NEWFILE}")"
+
+if [ "$(diff "${OLDFILE}" "${NEWFILE}")" != "" ]; then
+    echo "Schema has changed, updating the repo schema file"
+    echo "$DIFFSTR"
+    mv "${NEWFILE}" "${OLDFILE}"
+else
+    echo "Schema has not changed"
+fi
+rm -rf "${SCHEMA_TEMP_DIR}"

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,7 +139,9 @@ impl TryFrom<ConfigurationParser> for Configuration {
             Some(services) => {
                 let mut res: HashMap<String, Service> = HashMap::new();
                 for (service_name, service) in services {
-                    res.insert(service_name, serde_json::from_value(service)?);
+                    let service: Service = serde_json::from_value(service)?;
+
+                    res.insert(service_name, service);
                 }
                 Some(res)
             }

--- a/src/db/entities/host.rs
+++ b/src/db/entities/host.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use entities::host_group_members::HostToGroups;
 use sea_orm::entity::prelude::*;
 use sea_orm::IntoActiveModel;
 
@@ -46,24 +47,67 @@ impl Related<super::host_group::Entity> for Entity {
 
 impl ActiveModelBehavior for ActiveModel {}
 
-pub async fn find_by_name(name: &str, db: &DatabaseConnection) -> Result<Option<Model>, Error> {
-    match Entity::find().filter(Column::Name.eq(name)).one(db).await {
-        Ok(val) => Ok(val.into_iter().next()),
-        Err(err) => {
-            error!("Query failed while looking up host '{}': {:?}", name, err);
-            Err(err.into())
+impl Model {
+    /// Validate that the service checks for this host should still exist
+    ///
+    /// Used to clean up old service checks that are no longer needed when the host is removed from a group etc
+    ///
+    pub async fn prune_service_checks(&self, db: &DatabaseConnection) -> Result<(), Error> {
+        let result = Entity::find_by_id(self.id)
+            .find_with_linked(HostToGroups)
+            .all(db)
+            .await?;
+
+        debug!("{:#?}", result);
+
+        let (_host, host_groups) = match result.into_iter().next() {
+            Some(val) => val,
+            None => {
+                error!("Failed to find host {}", self.id);
+                return Err(Error::HostNotFound(self.id));
+            }
+        };
+
+        for host_group in host_groups {
+            debug!("Host group: {:?}", host_group);
+
+            let _services = host_group
+                .find_linked(super::service_group_link::GroupToServices)
+                .all(db)
+                .await?;
         }
+        // let service_checks = super::service_check::Entity::find()
+        //     .filter(super::service_check::Column::HostId.eq(self.id))
+        //     .all(db)
+        //     .await
+        //     .inspect_err(|err| {
+        //         error!(
+        //             "Failed to find service checks for host {} {} {}",
+        //             self.id, self.hostname, err,
+        //         )
+        //     })?;
+
+        Ok(())
     }
 }
 
 #[async_trait]
 impl MaremmaEntity for Model {
+    async fn find_by_name(name: &str, db: &DatabaseConnection) -> Result<Option<Model>, Error> {
+        match Entity::find().filter(Column::Name.eq(name)).one(db).await {
+            Ok(val) => Ok(val.into_iter().next()),
+            Err(err) => {
+                error!("Query failed while looking up host '{}': {:?}", name, err);
+                Err(err.into())
+            }
+        }
+    }
     async fn update_db_from_config(
-        db: Arc<DatabaseConnection>,
+        db: &DatabaseConnection,
         config: Arc<Configuration>,
     ) -> Result<(), Error> {
         for (name, host) in config.hosts.clone().into_iter() {
-            let model = match find_by_name(&name, db.as_ref()).await {
+            let model = match Model::find_by_name(&name, db).await {
                 Ok(val) => val,
                 Err(err) => {
                     error!("Failed to find host '{}': {:?}", name, err);
@@ -89,7 +133,7 @@ impl MaremmaEntity for Model {
 
                     if existing_host.is_changed() {
                         warn!("Updating {:?}", &existing_host);
-                        existing_host.save(db.as_ref()).await?;
+                        existing_host.save(db).await?;
                     } else {
                         debug!("No changes to {:?}", &existing_host);
                     }
@@ -102,7 +146,7 @@ impl MaremmaEntity for Model {
                         check: host.check.clone(),
                     }
                     .into_active_model();
-                    warn!("Creating Host {:?}", new_host.insert(db.as_ref()).await?);
+                    warn!("Creating Host {:?}", new_host.insert(db).await?);
                 }
             };
         }
@@ -125,7 +169,7 @@ mod tests {
 
     use sea_orm::IntoActiveModel;
     use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
-    use tracing::info;
+    use tracing::{debug, info};
 
     use crate::db::entities::MaremmaEntity;
     use crate::db::tests::test_setup;
@@ -163,7 +207,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_db_from_config() {
         let (db, config) = test_setup().await.expect("Failed to start test harness");
-        super::Model::update_db_from_config(db, config)
+        super::Model::update_db_from_config(&db, config)
             .await
             .expect("Failed to load config");
     }
@@ -176,12 +220,29 @@ mod tests {
             .await
             .expect("Failed to insert host");
 
-        let found_host = super::find_by_name(&super::test_host().name, db.as_ref())
+        let found_host = super::Model::find_by_name(&super::test_host().name, db.as_ref())
             .await
             .expect("Failed to query host");
 
         assert!(found_host.is_some());
 
         assert_eq!(found_host.unwrap().name, inserted_host.name);
+    }
+
+    #[tokio::test]
+    async fn test_prune_service_checks() {
+        let (db, _config) = test_setup().await.expect("Failed to start test harness");
+
+        let host = super::Entity::find()
+            .one(db.as_ref())
+            .await
+            .expect("Failed to run wquery")
+            .expect("Failed to find a host?");
+
+        debug!("{:?}", host);
+
+        host.prune_service_checks(db.as_ref())
+            .await
+            .expect("Failed to prune service checks");
     }
 }

--- a/src/db/entities/host.rs
+++ b/src/db/entities/host.rs
@@ -37,7 +37,7 @@ impl Related<super::service_check::Entity> for Entity {
 
 impl Related<super::host_group::Entity> for Entity {
     fn to() -> RelationDef {
-        super::host_group::Relation::Host.def()
+        super::host_group::Relation::Host.def().rev()
     }
 
     fn via() -> Option<RelationDef> {

--- a/src/db/entities/host_group.rs
+++ b/src/db/entities/host_group.rs
@@ -100,34 +100,30 @@ impl MaremmaEntity for Model {
             }
         }
 
-        if let Some(services) = config.services.as_ref() {
-            for (service_name, service) in services {
-                for group_name in service.host_groups.iter() {
-                    if known_group_list.contains(group_name) {
-                        continue;
-                    }
-                    if Model::find_by_name(group_name, db).await?.is_none() {
-                        debug!("Adding host group {}", group_name);
-                        Entity::insert(
-                            Model {
-                                id: Uuid::new_v4(),
-                                name: group_name.to_owned(),
-                            }
-                            .into_active_model(),
-                        )
-                        .exec_with_returning(db)
-                        .await?;
-                        warn!(
-                            "Added group {:?} from service {:?} to DB",
-                            &service_name, group_name
-                        );
-                    } else {
-                        debug!("Already have group {}", group_name);
-                    }
+        for (service_name, service) in &config.services {
+            for group_name in service.host_groups.iter() {
+                if known_group_list.contains(group_name) {
+                    continue;
+                }
+                if Model::find_by_name(group_name, db).await?.is_none() {
+                    debug!("Adding host group {}", group_name);
+                    Entity::insert(
+                        Model {
+                            id: Uuid::new_v4(),
+                            name: group_name.to_owned(),
+                        }
+                        .into_active_model(),
+                    )
+                    .exec_with_returning(db)
+                    .await?;
+                    warn!(
+                        "Added group {:?} from service {:?} to DB",
+                        &service_name, group_name
+                    );
+                } else {
+                    debug!("Already have group {}", group_name);
                 }
             }
-        } else {
-            warn!("No services found in configuration");
         }
 
         Ok(())

--- a/src/db/entities/host_group_members.rs
+++ b/src/db/entities/host_group_members.rs
@@ -40,7 +40,13 @@ impl Linked for HostToGroups {
     type ToEntity = entities::host_group::Entity;
 
     fn link(&self) -> Vec<RelationDef> {
-        vec![Relation::Host.def().rev(), Relation::HostGroup.def()]
+        vec![
+            Relation::Host.def().rev(),
+            Entity::belongs_to(super::host_group::Entity)
+                .from(Column::GroupId)
+                .to(super::host_group::Column::Id)
+                .into(),
+        ]
     }
 }
 

--- a/src/db/entities/host_group_members.rs
+++ b/src/db/entities/host_group_members.rs
@@ -97,8 +97,12 @@ impl Entity {
 
 #[async_trait]
 impl MaremmaEntity for Model {
+    async fn find_by_name(_name: &str, _db: &DatabaseConnection) -> Result<Option<Model>, Error> {
+        todo!()
+    }
+
     async fn update_db_from_config(
-        db: Arc<DatabaseConnection>,
+        db: &DatabaseConnection,
         config: Arc<Configuration>,
     ) -> Result<(), Error> {
         // group -> (group def, host ids)
@@ -110,7 +114,7 @@ impl MaremmaEntity for Model {
         }
 
         for (host_name, host) in config.hosts.clone() {
-            let db_host = match super::host::find_by_name(&host_name, db.as_ref()).await? {
+            let db_host = match super::host::Model::find_by_name(&host_name, db).await? {
                 Some(host) => host,
                 None => {
                     error!(
@@ -127,7 +131,7 @@ impl MaremmaEntity for Model {
                 } else {
                     let group = super::host_group::Entity::find()
                         .filter(super::host_group::Column::Name.eq(&group_name))
-                        .one(db.as_ref())
+                        .one(db)
                         .await?;
 
                     match group {
@@ -146,7 +150,7 @@ impl MaremmaEntity for Model {
         for (group_name, (group, host_ids)) in inverted_group_list {
             debug!("Ensuring links between group {} and hosts", group_name);
             for host_id in host_ids {
-                Entity::upsert(db.as_ref(), &host_id, &group.id).await?;
+                Entity::upsert(db, &host_id, &group.id).await?;
             }
         }
         Ok(())
@@ -163,16 +167,16 @@ mod tests {
         let (db, config) = test_setup().await.expect("Failed to start test harness");
 
         // have to include this because otherwise the members won't exist :)
-        super::super::host::Model::update_db_from_config(db.clone(), config.clone())
+        super::super::host::Model::update_db_from_config(&db, config.clone())
             .await
             .expect("Failed to update hosts from config");
 
         // have to include this because otherwise the members won't exist :)
-        super::super::host_group::Model::update_db_from_config(db.clone(), config.clone())
+        super::super::host_group::Model::update_db_from_config(&db, config.clone())
             .await
             .expect("Failed to update host groups from config");
 
-        super::Model::update_db_from_config(db.clone(), config)
+        super::Model::update_db_from_config(&db, config)
             .await
             .expect("Failed to load config");
 

--- a/src/db/entities/mod.rs
+++ b/src/db/entities/mod.rs
@@ -7,6 +7,8 @@ pub mod host_group_members;
 pub mod service;
 pub mod service_check;
 pub mod service_check_history;
+pub mod service_group_link;
+pub mod service_v1;
 pub mod session;
 #[cfg(test)]
 pub mod tests;
@@ -15,7 +17,11 @@ pub mod user;
 #[async_trait]
 pub trait MaremmaEntity {
     async fn update_db_from_config(
-        db: Arc<DatabaseConnection>,
+        db: &DatabaseConnection,
         config: Arc<Configuration>,
     ) -> Result<(), Error>;
+
+    async fn find_by_name(name: &str, db: &DatabaseConnection) -> Result<Option<Self>, Error>
+    where
+        Self: Sized;
 }

--- a/src/db/entities/service.rs
+++ b/src/db/entities/service.rs
@@ -61,106 +61,101 @@ impl MaremmaEntity for Model {
         db: &DatabaseConnection,
         config: Arc<Configuration>,
     ) -> Result<(), Error> {
-        if let Some(services) = config.services.as_ref() {
-            for (service_name, service) in services {
-                // this is janky but we need to flatten it using serde to get the "extra" fields
-                let extra_config: Json = serde_json::to_value(service.extra_config.clone())
-                    .inspect_err(|err| {
-                        error!(
-                            "Failed to convert extra_config into JSON for {} error={:?}",
-                            service_name, err
-                        )
-                    })?;
-
-                let mut service_value = serde_json::to_value(service).inspect_err(|err| {
+        for (service_name, service) in &config.services {
+            // this is janky but we need to flatten it using serde to get the "extra" fields
+            let extra_config: Json = serde_json::to_value(service.extra_config.clone())
+                .inspect_err(|err| {
                     error!(
-                        "Failed to convert service into JsonValue for {} error={:?}",
+                        "Failed to convert extra_config into JSON for {} error={:?}",
                         service_name, err
                     )
                 })?;
 
-                if let Some(service_object) = service_value.as_object_mut() {
-                    if !service_object.contains_key("id")
-                        || Some(&serde_json::Value::Null) == service_object.get("id")
-                    {
-                        debug!("Adding ID to service: {}", service_name);
-                        if let Some(id) = service_object.get_mut("id") {
-                            *id = json!(Uuid::new_v4());
-                        } else {
-                            return Err(Error::Configuration(format!(
-                                "Failed to add ID to service '{}', check the configuration!",
-                                service_name
-                            )));
-                        };
-                    }
-                    service_object.insert("name".to_string(), json!(service_name));
-                    service_object.insert("extra_config".to_string(), json!(extra_config));
-                } else {
-                    error!("Failed to convert service to object: {:?}", service_value);
-                    return Err(Error::Configuration(format!(
-                        "Failed to convert service '{}' to object, check the configuration!",
-                        service_name
-                    )));
-                }
-                debug!("Looking for {}", service_name);
-                // check if we have one and add it if not
-                match Entity::find()
-                    .filter(Column::Name.eq(service_name))
-                    .one(db)
-                    .await
+            let mut service_value = serde_json::to_value(service).inspect_err(|err| {
+                error!(
+                    "Failed to convert service into JsonValue for {} error={:?}",
+                    service_name, err
+                )
+            })?;
+
+            if let Some(service_object) = service_value.as_object_mut() {
+                if !service_object.contains_key("id")
+                    || Some(&serde_json::Value::Null) == service_object.get("id")
                 {
-                    Ok(Some(res)) => {
-                        debug!("found it!");
-                        let mut res = res.into_active_model();
-                        res.name.set_if_not_equals(service_name.clone());
-                        if let Err(err) = res.set_from_json(service_value) {
-                            error!("Error setting service from json: {:?}", err);
-                            return Err(err.into());
-                        };
-
-                        if res.is_changed() {
-                            #[cfg(any(test, debug_assertions))]
-                            {
-                                eprintln!("about to update this: {:?}", res);
-                                eprintln!("Source: {:?}", service);
-                            }
-                            res.update(db).await?
-                        } else {
-                            eprintln!("try into model");
-                            res.try_into_model().inspect_err(|err| {
-                                error!("Failed to convert {:?} to model: {:?}", service_name, err)
-                            })?
-                        }
-                    }
-                    Ok(None) => {
-                        debug!("didn't find it!");
-                        // insert the service if we can't find it
-                        let mut am = ActiveModel::new();
-
-                        let jsonvalue =
-                            serde_json::to_value(&service_value).inspect_err(|err| {
-                                error!("Failed to turn thing into json value? err={:?}", err)
-                            })?;
-
-                        am.set_from_json(jsonvalue.clone()).inspect_err(|err| {
-                            error!(
-                                "Failed to set model values from JSON {:?} error={:?}",
-                                jsonvalue, err
-                            )
-                        })?;
-                        am.id.set_if_not_equals(Uuid::new_v4());
-                        #[cfg(any(test, debug_assertions))]
-                        eprintln!("about to update this: {:?}", am);
-
-                        debug!("Creating service: {:?}", am);
-                        Entity::insert(am).exec_with_returning(db).await?
-                    }
-
-                    Err(err) => return Err(err.into()),
-                };
+                    debug!("Adding ID to service: {}", service_name);
+                    if let Some(id) = service_object.get_mut("id") {
+                        *id = json!(Uuid::new_v4());
+                    } else {
+                        return Err(Error::Configuration(format!(
+                            "Failed to add ID to service '{}', check the configuration!",
+                            service_name
+                        )));
+                    };
+                }
+                service_object.insert("name".to_string(), json!(service_name));
+                service_object.insert("extra_config".to_string(), json!(extra_config));
+            } else {
+                error!("Failed to convert service to object: {:?}", service_value);
+                return Err(Error::Configuration(format!(
+                    "Failed to convert service '{}' to object, check the configuration!",
+                    service_name
+                )));
             }
-        } else {
-            error!("No services in config!");
+            debug!("Looking for {}", service_name);
+            // check if we have one and add it if not
+            match Entity::find()
+                .filter(Column::Name.eq(service_name))
+                .one(db)
+                .await
+            {
+                Ok(Some(res)) => {
+                    debug!("found it!");
+                    let mut res = res.into_active_model();
+                    res.name.set_if_not_equals(service_name.clone());
+                    if let Err(err) = res.set_from_json(service_value) {
+                        error!("Error setting service from json: {:?}", err);
+                        return Err(err.into());
+                    };
+
+                    if res.is_changed() {
+                        #[cfg(any(test, debug_assertions))]
+                        {
+                            eprintln!("about to update this: {:?}", res);
+                            eprintln!("Source: {:?}", service);
+                        }
+                        res.update(db).await?
+                    } else {
+                        eprintln!("try into model");
+                        res.try_into_model().inspect_err(|err| {
+                            error!("Failed to convert {:?} to model: {:?}", service_name, err)
+                        })?
+                    }
+                }
+                Ok(None) => {
+                    debug!("didn't find it!");
+                    // insert the service if we can't find it
+                    let mut am = ActiveModel::new();
+
+                    let jsonvalue = serde_json::to_value(&service_value).inspect_err(|err| {
+                        error!("Failed to turn thing into json value? err={:?}", err)
+                    })?;
+
+                    am.set_from_json(jsonvalue.clone()).inspect_err(|err| {
+                        error!(
+                            "Failed to set model values from JSON {:?} error={:?}",
+                            jsonvalue, err
+                        )
+                    })?;
+                    am.id.set_if_not_equals(Uuid::new_v4());
+                    #[cfg(any(test, debug_assertions))]
+                    eprintln!("about to update this: {:?}", am);
+
+                    debug!("Creating service: {:?}", am);
+                    Entity::insert(am).exec_with_returning(db).await?
+                }
+
+                Err(err) => return Err(err.into()),
+            };
         }
 
         Ok(())

--- a/src/db/entities/service_group_link.rs
+++ b/src/db/entities/service_group_link.rs
@@ -1,0 +1,114 @@
+//! Links services to groups
+
+use crate::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "service_group_link")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub service_id: Uuid,
+    pub group_id: Uuid,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter)]
+pub enum Relation {
+    Service,
+    HostGroup,
+}
+
+impl RelationTrait for Relation {
+    fn def(&self) -> RelationDef {
+        match self {
+            Self::Service => Entity::belongs_to(super::service::Entity)
+                .from(Column::ServiceId)
+                .to(super::service::Column::Id)
+                .into(),
+            Self::HostGroup => Entity::belongs_to(super::host_group::Entity)
+                .from(Column::GroupId)
+                .to(super::host_group::Column::Id)
+                .into(),
+        }
+    }
+}
+
+// This lets you find related groups for a service
+pub struct ServiceToGroups;
+
+impl Linked for ServiceToGroups {
+    type FromEntity = entities::service::Entity;
+    type ToEntity = entities::host_group::Entity;
+
+    fn link(&self) -> Vec<RelationDef> {
+        vec![
+            Relation::Service.def().rev(),
+            Entity::belongs_to(super::host_group::Entity)
+                .from(Column::GroupId)
+                .to(super::host_group::Column::Id)
+                .into(),
+        ]
+    }
+}
+
+// This lets you find related services for a group
+pub struct GroupToServices;
+
+impl Linked for GroupToServices {
+    type FromEntity = super::host_group::Entity;
+    type ToEntity = super::service::Entity;
+
+    fn link(&self) -> Vec<RelationDef> {
+        vec![
+            Relation::HostGroup.def().rev(),
+            Entity::belongs_to(super::service::Entity)
+                .from(Column::ServiceId)
+                .to(super::service::Column::Id)
+                .into(),
+        ]
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+#[async_trait]
+impl MaremmaEntity for Model {
+    async fn find_by_name(_name: &str, _db: &DatabaseConnection) -> Result<Option<Model>, Error> {
+        todo!()
+    }
+
+    async fn update_db_from_config(
+        _db: &DatabaseConnection,
+        _config: Arc<Configuration>,
+    ) -> Result<(), Error> {
+        // todo!();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::tests::test_setup;
+    use crate::prelude::*;
+
+    #[tokio::test]
+    async fn test_update_db_from_config() {
+        let (db, config) = test_setup().await.expect("Failed to start test harness");
+
+        // have to include this because otherwise the members won't exist :)
+        super::super::host::Model::update_db_from_config(&db, config.clone())
+            .await
+            .expect("Failed to update hosts from config");
+
+        // have to include this because otherwise the members won't exist :)
+        super::super::host_group::Model::update_db_from_config(&db, config.clone())
+            .await
+            .expect("Failed to update host groups from config");
+
+        super::Model::update_db_from_config(&db, config)
+            .await
+            .expect("Failed to load config");
+
+        let host_group_members = super::Entity::find().all(db.as_ref()).await.unwrap();
+        assert_ne!(host_group_members.len(), 1);
+    }
+}

--- a/src/db/entities/service_v1.rs
+++ b/src/db/entities/service_v1.rs
@@ -1,0 +1,24 @@
+use sea_orm::entity::prelude::*;
+
+use crate::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "service")]
+/// V1 Service Model, used for the initial version of the service table before [crate::db::migrations::m20240825_create_service_group_link_table] was done.
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false, name = "id")]
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    /// A list of host group names
+    pub host_groups: serde_json::Value,
+    pub service_type: ServiceType,
+    pub cron_schedule: String,
+    #[serde(flatten)]
+    pub extra_config: Option<serde_json::Value>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, sea_orm::DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/db/entities/tests/service_check.rs
+++ b/src/db/entities/tests/service_check.rs
@@ -184,7 +184,7 @@ async fn test_service_check_fk_service() {
 async fn test_full_service_check() {
     let (db, config) = test_setup().await.expect("Failed to set up test config");
 
-    crate::db::update_db_from_config(db.clone(), config.clone())
+    crate::db::update_db_from_config(db.as_ref(), config.clone())
         .await
         .unwrap();
 

--- a/src/db/migrations/m20240825_create_service_group_link_table.rs
+++ b/src/db/migrations/m20240825_create_service_group_link_table.rs
@@ -1,0 +1,147 @@
+use std::collections::HashMap;
+
+use sea_orm::{ActiveModelBehavior, ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm_migration::prelude::*;
+
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::db::entities;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20240822_create_service_group_link_table" // Make sure this matches with the file name
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    // Define how to apply this migration: Create the table.
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(ServiceGroupLink::Table)
+                    .col(
+                        ColumnDef::new(ServiceGroupLink::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ServiceGroupLink::ServiceId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(ServiceGroupLink::GroupId).uuid().not_null())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("service_group_link_service_id")
+                            .from(ServiceGroupLink::Table, ServiceGroupLink::ServiceId)
+                            .to(
+                                super::m20240802_create_service_table::Service::Table,
+                                super::m20240802_create_service_table::Service::Id,
+                            )
+                            .on_update(ForeignKeyAction::Cascade)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("service_group_link_group_id")
+                            .from(ServiceGroupLink::Table, ServiceGroupLink::GroupId)
+                            .to(
+                                super::m20240802_create_host_group_table::HostGroup::Table,
+                                super::m20240802_create_host_group_table::HostGroup::Id,
+                            )
+                            .on_update(ForeignKeyAction::Cascade)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        let db = manager.get_connection();
+        let services = entities::service_v1::Entity::find().all(db).await?;
+
+        let mut service_group_pairs: Vec<(Uuid, String)> = Vec::new();
+
+        for service in services {
+            let service_id = service.id;
+            let host_groups: Vec<String> = serde_json::from_value(service.host_groups)
+                .map_err(|err| DbErr::Custom(err.to_string()))?;
+
+            for host_group in host_groups {
+                service_group_pairs.push((service_id, host_group));
+            }
+        }
+
+        let mut group_ids = HashMap::<String, Uuid>::new();
+
+        for (service_id, host_group) in service_group_pairs {
+            // do we have it cached?
+            let mut group_id = group_ids.get(&host_group).cloned();
+
+            if group_id.is_none() {
+                // check the db
+                if let Some(host_group) = entities::host_group::Entity::find()
+                    .filter(entities::host_group::Column::Name.eq(&host_group))
+                    .one(db)
+                    .await?
+                {
+                    group_ids.insert(host_group.name.clone(), host_group.id);
+                    group_id = Some(host_group.id);
+
+                    // ensure the service_group_link record exists
+                    if entities::service_group_link::Entity::find()
+                        .filter(
+                            entities::service_group_link::Column::ServiceId
+                                .eq(service_id)
+                                .and(
+                                    entities::service_group_link::Column::GroupId.eq(host_group.id),
+                                ),
+                        )
+                        .one(db)
+                        .await?
+                        .is_none()
+                    {
+                        let mut sglam = entities::service_group_link::ActiveModel::new();
+                        sglam.id.set_if_not_equals(Uuid::new_v4());
+                        sglam.service_id.set_if_not_equals(service_id);
+                        sglam.group_id.set_if_not_equals(host_group.id);
+                        debug!(
+                            "adding service group link for service_id: {:?}, group_id: {:?}",
+                            service_id, host_group
+                        );
+                        sglam.insert(db).await?;
+                    }
+                } else {
+                    // TODO: maybe create the host group? it really should be there already
+                    return Err(DbErr::Custom(format!(
+                        "Couldn't find the host group {} in the database?",
+                        host_group
+                    )));
+                }
+            }
+            eprintln!("Found group_id: {:?}", group_id);
+        }
+        Ok(())
+    }
+
+    // Define how to rollback this migration
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // TODO: reverse the migration, need to ensure the data goes back into the service table
+        manager
+            .drop_table(Table::drop().table(ServiceGroupLink::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(Iden)]
+pub enum ServiceGroupLink {
+    Table,
+    Id,
+    ServiceId,
+    GroupId,
+}

--- a/src/db/migrations/m20240825_drop_service_host_groups.rs
+++ b/src/db/migrations/m20240825_drop_service_host_groups.rs
@@ -1,0 +1,48 @@
+//! Dropping the host_groups column from the Service table
+
+use sea_orm::sea_query::{self, Alias, ColumnDef, Table};
+use sea_orm::{DbErr, Iden};
+use sea_orm_migration::{MigrationName, MigrationTrait, SchemaManager};
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20240825_drop_service_host_groups" // Make sure this matches with the file name
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    // Define how to apply this migration: Create the table.
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .drop_column(Alias::new("host_groups"))
+                    .table(Service::Table)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    // Define how to rollback this migration
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // TODO: reverse the migration
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .add_column(ColumnDef::new(Service::HostGroups).string().not_null())
+                    .table(Service::Table)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+pub enum Service {
+    Table,
+    HostGroups,
+}

--- a/src/db/migrations/mod.rs
+++ b/src/db/migrations/mod.rs
@@ -6,3 +6,5 @@ pub(crate) mod m20240802_create_service_table;
 pub(crate) mod m20240807_create_service_check_hstory_table;
 pub(crate) mod m20240810_create_user_table;
 pub(crate) mod m20240822_create_session_table;
+pub(crate) mod m20240825_create_service_group_link_table;
+pub(crate) mod m20240825_drop_service_host_groups;

--- a/src/db/migrator.rs
+++ b/src/db/migrator.rs
@@ -14,6 +14,7 @@ impl MigratorTrait for Migrator {
             Box::new(super::migrations::m20240807_create_service_check_hstory_table::Migration),
             Box::new(super::migrations::m20240810_create_user_table::Migration),
             Box::new(super::migrations::m20240822_create_session_table::Migration),
+            Box::new(super::migrations::m20240825_create_service_group_link_table::Migration),
         ]
     }
 }

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -7,7 +7,7 @@ use crate::log::setup_logging;
 async fn test_next_service_check() {
     let (db, config) = test_setup().await.expect("Failed to start test harness");
 
-    crate::db::update_db_from_config(db.clone(), config.clone())
+    crate::db::update_db_from_config(db.as_ref(), config.clone())
         .await
         .unwrap();
 
@@ -31,7 +31,7 @@ pub(crate) async fn test_setup() -> Result<(Arc<DatabaseConnection>, Arc<Configu
 
     let config = Configuration::load_test_config().await;
 
-    crate::db::update_db_from_config(db.clone(), config.clone())
+    crate::db::update_db_from_config(&db, config.clone())
         .await
         .expect("Failed to update DB from config");
     Ok((db, config))

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,10 +38,7 @@ async fn main() -> Result<(), ExitCode> {
                 ExitCode::FAILURE
             })?);
 
-            if update_db_from_config(db.clone(), config.clone())
-                .await
-                .is_err()
-            {
+            if update_db_from_config(&db, config.clone()).await.is_err() {
                 return Err(ExitCode::FAILURE);
             };
 

--- a/src/services/tls/tests.rs
+++ b/src/services/tls/tests.rs
@@ -251,7 +251,7 @@ fn test_service_parser() {
     let mut extra_config = std::collections::HashMap::new();
 
     extra_config.insert("port".to_string(), json! {1234});
-    let service = super::Service {
+    let mut service = super::Service {
         id: Uuid::new_v4(),
         name: Some("Hello world".to_string()),
         description: None,
@@ -273,7 +273,7 @@ fn test_service_parser() {
 
 #[test]
 fn test_failed_service_parser() {
-    let service = super::Service {
+    let mut service = super::Service {
         id: Uuid::new_v4(),
         name: Some("Hello world".to_string()),
         description: None,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -112,6 +112,7 @@ pub(crate) async fn build_app(state: WebState, config: &Configuration) -> Result
         .route("/service_check/:service_check_id", get(service_check_get))
         .route("/hosts", get(views::host::hosts))
         .route("/host/:host_id", get(views::host::host))
+        .route("/host/:host_id/delete", post(views::host::delete_host))
         .route("/service/:service_id", get(notimplemented))
         .route("/host_group/:group_id", get(host_group))
         .route(

--- a/src/web/views/host_group.rs
+++ b/src/web/views/host_group.rs
@@ -168,6 +168,8 @@ pub(crate) async fn host_group_member_delete(
         group_id.hyphenated()
     );
 
+    // TODO: unpick the group -> service -> host -> check chain
+
     Ok(Redirect::to(&format!(
         "/host_group/{}?message=Removed {} from '{}'",
         group_id, host.hostname, group.name

--- a/src/web/views/prelude.rs
+++ b/src/web/views/prelude.rs
@@ -26,6 +26,15 @@ pub(crate) enum Order {
     Desc,
 }
 
+impl std::fmt::Display for Order {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Order::Asc => write!(f, "asc"),
+            Order::Desc => write!(f, "desc"),
+        }
+    }
+}
+
 impl From<Order> for sea_orm::Order {
     fn from(value: Order) -> Self {
         match value {

--- a/templates/host.html
+++ b/templates/host.html
@@ -6,9 +6,28 @@
 
 {% block content %}
 
-<p>hostname: {{hostname}}</p>
-<!-- <p>host_id: {{host_id}}</p> -->
-<p>host check: {{check}}</p>
+<p>hostname: {{host.name}}</p>
+
+<script type="text/javascript">
+    document.addEventListener('DOMContentLoaded', function() {
+        const form = document.getElementById('deleteHost');
+        if (form) {
+            form.addEventListener('submit', function(event) {
+                event.preventDefault();
+                if (confirm('Are you sure you want to delete this host?')) {
+                    this.submit();
+                }
+            });
+        }
+    });
+
+</script>
+
+<form method="post" action="/host/{{host.id}}/delete" id="deleteHost">
+    <input type="submit" class="btn btn-danger" value="Delete Host"
+        style="float:right;" />
+</form>
+<p>host check: {{host.check}}</p>
 <p>host_groups: {% for host_group in host_groups %}<a
         href="/host_group/{{host_group.id}}">{{ host_group.name }}</a>
     {% endfor %}</p>
@@ -68,7 +87,7 @@
                 <input type="submit" class="btn btn-warning"
                     value="Delete" />
                 <input type="hidden" name="redirect_to"
-                    value="/host/{{host_id}}" />
+                    value="/host/{{host.id}}" />
             </form>
         </td>
     </tr>

--- a/templates/host_group.html
+++ b/templates/host_group.html
@@ -2,12 +2,23 @@
 
 {% block content %}
 
-<h1>{{host_group.name}}</h1>
+{% if let Some(message) = message %}
+<div class="alert alert-success" role="alert">
+    {{ message }}
+</div>
+{% endif %}
+
+<h1>Host Group: {{host_group.name}}</h1>
 
 <h3>Hosts</h3>
+
 <table class="checktable">
     <thead>
-        <th>Group Member</th>
+        <th>
+            <a href="?ord={{crate::web::views::prelude::Order::Asc}}">Hostname
+                &nbsp;&nbsp;⬆️</a>&nbsp;
+            <a href="?ord={{crate::web::views::prelude::Order::Desc}}">⬇️</a>
+        </th>
         <th>&nbsp;</th>
     </thead>
     {% for member in members %}

--- a/templates/hosts.html
+++ b/templates/hosts.html
@@ -11,9 +11,11 @@
 <table class="checktable">
     <thead>
         <th>
-            <a href="?ord=asc&field=host&search={{search_string}}">Host
+            <a
+                href="?ord={{crate::web::views::prelude::Order::Asc}}&field=host&search={{search_string}}">Host
                 &nbsp;&nbsp;⬆️</a>&nbsp;
-            <a href="?ord=desc&field=host&search={{search_string}}">⬇️</a>
+            <a
+                href="?ord={{crate::web::views::prelude::Order::Desc}}&field=host&search={{search_string}}">⬇️</a>
         </th>
     </thead>
     {% for host in hosts %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,24 +12,37 @@ There are {{ num_checks }} service checks enabled.
   <thead>
     <tr>
       <th>
-        <a href="/?ord=asc&field=host">Host &nbsp;&nbsp;⬆️</a>&nbsp;
-        <a href="/?ord=desc&field=host">⬇️</a>
+        <a
+          href="/?ord={{crate::web::views::prelude::Order::Asc}}&field=host">Host
+          &nbsp;&nbsp;⬆️</a>&nbsp;
+        <a
+          href="/?ord={{crate::web::views::prelude::Order::Desc}}&field=host">⬇️</a>
       </th>
       <th>
-        <a href="/?ord=asc&field=host">Service&nbsp;&nbsp;⬆️</a>&nbsp;
-        <a href="/?ord=desc&field=host">⬇️</a>
+        <a
+          href="/?ord={{crate::web::views::prelude::Order::Asc}}&field=host">Service&nbsp;&nbsp;⬆️</a>&nbsp;
+        <a
+          href="/?ord={{crate::web::views::prelude::Order::Desc}}&field=host">⬇️</a>
       </th>
       <th>
-        <a href="/?ord=asc&field=status">Status&nbsp;&nbsp;⬆️</a>&nbsp;
-        <a href="/?ord=desc&field=status">⬇️</a>
+        <a
+          href="/?ord={{crate::web::views::prelude::Order::Asc}}&field=status">Status&nbsp;&nbsp;⬆️</a>&nbsp;
+        <a
+          href="/?ord={{crate::web::views::prelude::Order::Desc}}&field=status">⬇️</a>
       </th>
       <th>
-        <a href="/?ord=asc&field=lastupdated">Last Check&nbsp;&nbsp;⬆️</a>&nbsp;
-        <a href="/?ord=desc&field=lastupdated">⬇️</a>
+        <a
+          href="/?ord={{crate::web::views::prelude::Order::Asc}}&field=lastupdated">Last
+          Check&nbsp;&nbsp;⬆️</a>&nbsp;
+        <a
+          href="/?ord={{crate::web::views::prelude::Order::Desc}}&field=lastupdated">⬇️</a>
       </th>
       <th>
-        <a href="/?ord=asc&field=nextcheck">Next Check&nbsp;&nbsp;⬆️</a>&nbsp;
-        <a href="/?ord=desc&field=nextcheck">⬇️</a>
+        <a
+          href="/?ord={{crate::web::views::prelude::Order::Asc}}&field=nextcheck">Next
+          Check&nbsp;&nbsp;⬆️</a>&nbsp;
+        <a
+          href="/?ord={{crate::web::views::prelude::Order::Desc}}&field=nextcheck">⬇️</a>
       </th>
     </tr>
   </thead>

--- a/templates/service_check.html
+++ b/templates/service_check.html
@@ -3,8 +3,7 @@
 {% block content %}
 
 {% if let Some(message) = message %}
-<div class="alert alert-{{ status }}" <div
-    class="alert alert-secondary" role="alert">
+<div class="alert alert-{{ status }}" role="alert">
     {{ message }}
 </div>
 {% endif %}

--- a/templates/table_checks.html
+++ b/templates/table_checks.html
@@ -2,14 +2,26 @@
 <table width="100%">
     <thead>
         <tr>
-            <th><a href="/?ord=asc&field=host">Hostname 🔼</a> /
-                <a href="/?ord=desc&field=host">🔽</a></th>
-            <th><a href="/?ord=desc&field=check">Check 🔽</a> /
-                <a href="/?ord=asc&field=check">🔼</a></th>
-            <th><a href="/?ord=asc&field=status">Status 🔼</a> /
-                <a href="/?ord=desc&field=status">🔽</a></th>
-            <th><a href="/?ord=asc&field=lastupdated">Last Updated 🔼</a> /
-                <a href="/?ord=desc&field=lastupdated">🔽</a></th>
+            <th><a
+                    href="/?ord={{crate::web::views::prelude::Order::Asc}}&field=host">Hostname
+                    🔼</a> /
+                <a
+                    href="/?ord={{crate::web::views::prelude::Order::Desc}}&field=host">🔽</a></th>
+            <th><a
+                    href="/?ord={{crate::web::views::prelude::Order::Desc}}&field=check">Check
+                    🔽</a> /
+                <a
+                    href="/?ord={{crate::web::views::prelude::Order::Asc}}&field=check">🔼</a></th>
+            <th><a
+                    href="/?ord={{crate::web::views::prelude::Order::Asc}}&field=status">Status
+                    🔼</a> /
+                <a
+                    href="/?ord={{crate::web::views::prelude::Order::Desc}}&field=status">🔽</a></th>
+            <th><a
+                    href="/?ord={{crate::web::views::prelude::Order::Asc}}&field=lastupdated">Last
+                    Updated 🔼</a> /
+                <a
+                    href="/?ord={{crate::web::views::prelude::Order::Desc}}&field=lastupdated">🔽</a></th>
         </tr>
     </thead>
     {% for check in checks %}


### PR DESCRIPTION
```
fix(schema): updated schema to remove service null value
feat(web): allow deleting hosts
fix(web): use linked records properly to find hosts, way less code
fix(db): cleaning up relations, starting on service_group_link updates
feat(db): Service group link table instead of having to parse host groups from service row
fix(code): db migrations are now done in a transaction
fix(code): update_db_from_config is now done in a transaction
feat(db): adding find_by_name as trait method for all things (well, where it makes sense)
fix(web): using enums instead of strings for some links
feat(web): can remove hosts from groups in the UI
fix(jsonschema): fixing up the default service ID field
```