### PR TITLE
fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,20 +11,32 @@ use maremma::db::update_db_from_config;
 use opentelemetry::metrics::MeterProvider;
 use std::process::ExitCode;
 
-#[tokio::main(flavor = "multi_thread")]
 #[cfg(not(tarpaulin_include))] // ignore for code coverage
-async fn main() -> Result<(), ExitCode> {
-    use maremma::db::get_connect_string;
-    use maremma::services::oneshot::run_oneshot;
-    use maremma::shepherd::shepherd;
-
+fn main() -> Result<(), ExitCode> {
     let cli = CliOpts::parse();
     if let Err(err) = setup_logging(cli.debug(), cli.db_debug(), cli.tokio_console()) {
-        println!("Failed to setup logging: {:?}", err);
+        eprintln!("Failed to setup logging: {:?}", err);
         return Err(ExitCode::from(1));
     };
 
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let num_cpus = num_cpus::get();
+    let threads = std::cmp::min(4, num_cpus);
+    debug!("Starting {} threads", threads);
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(threads)
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async_main(cli))
+}
+
+#[cfg(not(tarpaulin_include))] // ignore for code coverage
+async fn async_main(cli: CliOpts) -> Result<(), ExitCode> {
+    use maremma::db::get_connect_string;
+    use maremma::services::oneshot::run_oneshot;
+    use maremma::shepherd::shepherd;
 
     if let Actions::ExportConfigSchema = cli.action {
         let schema = schemars::schema_for!(Configuration);

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use maremma::db::update_db_from_config;
 use opentelemetry::metrics::MeterProvider;
 use std::process::ExitCode;
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread")]
 #[cfg(not(tarpaulin_include))] // ignore for code coverage
 async fn main() -> Result<(), ExitCode> {
     use maremma::db::get_connect_string;

--- a/src/web/views/service.rs
+++ b/src/web/views/service.rs
@@ -41,9 +41,7 @@ pub(crate) async fn service(
         }
     };
 
-    let service_checks = FullServiceCheck::get_by_service_id(service_id, &db_lock)
-        .await
-        .map_err(Error::from)?;
+    let service_checks = FullServiceCheck::get_by_service_id(service_id, &db_lock).await?;
     drop(db_lock);
     Ok(ServiceTemplate {
         title: service.name.clone(),


### PR DESCRIPTION
- explicit thread counts on startup for `tokio` runtime, setting a minimum of four
- found a possible race in lifetime handling for next service checks
- clippy-calming