### PR TITLE
Use list layout for host groups

### DIFF
--- a/src/web/views/host_group.rs
+++ b/src/web/views/host_group.rs
@@ -29,7 +29,6 @@ pub(crate) struct HostGroupsTemplate {
 pub(crate) struct HostGroupData {
     id: Uuid,
     name: String,
-    hosts: usize,
 }
 
 pub(crate) async fn host_groups(
@@ -39,7 +38,6 @@ pub(crate) async fn host_groups(
     let user = check_login(claims)?;
     let res = host_group::Entity::find()
         .order_by_asc(host_group::Column::Name)
-        .find_with_linked(host_group_members::GroupToHosts)
         .all(state.db.as_ref())
         .await
         .map_err(|e| {
@@ -49,10 +47,9 @@ pub(crate) async fn host_groups(
 
     let host_groups = res
         .into_iter()
-        .map(|(group, hosts)| HostGroupData {
+        .map(|group| HostGroupData {
             id: group.id,
             name: group.name,
-            hosts: hosts.len(),
         })
         .collect();
 
@@ -352,7 +349,25 @@ mod tests {
 
         assert!(res.is_ok());
 
-        let response = res.into_response();
+        let template = res.expect("Failed to render host groups");
+        let first_group = template
+            .host_groups
+            .first()
+            .expect("No host groups found in test data");
+        let rendered = template.to_string();
+
+        assert!(rendered.contains("Host Groups"));
+        assert!(rendered.contains("app-table"));
+        assert!(rendered.contains("Host Group</th>"));
+        assert!(rendered.contains(&format!("{} host groups", template.host_groups.len())));
+        assert!(rendered.contains(&format!(
+            "href=\"{}/{}\"",
+            Urls::HostGroup,
+            first_group.id
+        )));
+        assert!(rendered.contains(&first_group.name));
+
+        let response = template.into_response();
 
         assert_eq!(response.status(), StatusCode::OK);
     }

--- a/templates/host_groups.html
+++ b/templates/host_groups.html
@@ -5,24 +5,29 @@
 <section class="app-stack">
   <div class="app-card">
     <div class="app-card-header">
-      <div>
-        <h1 class="app-section-title">Host Groups</h1>
-        <p class="app-section-subtitle">Collections of hosts used to organize checks.</p>
-      </div>
+      <h1 class="app-section-title">Host Groups</h1>
+      <div class="app-muted">{{ host_groups.len() }} host groups</div>
     </div>
     <div class="app-card-body">
-      <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-        {% for group in host_groups %}
-        <a href="{{Urls::HostGroup}}/{{group.id}}" class="app-panel hover:border-slate-300 hover:bg-slate-50">
-          <div class="flex items-start justify-between gap-4">
-            <div>
-              <div class="text-base font-semibold text-slate-900">{{group.name}}</div>
-              <div class="app-muted mt-1">{{group.hosts}} hosts</div>
-            </div>
-            <span class="app-badge app-badge-muted">Group</span>
-          </div>
-        </a>
-        {% endfor %}
+      <div class="app-table-wrap">
+        <div class="overflow-x-auto">
+          <table class="app-table">
+            <thead class="app-table-head">
+              <tr>
+                <th class="app-th">Host Group</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-200 bg-white">
+              {% for group in host_groups %}
+              <tr class="app-row">
+                <td class="app-td">
+                  <a href="{{Urls::HostGroup}}/{{group.id}}" class="app-link">{{group.name}}</a>
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- switch `/host_groups` from the card grid to the same table-style list used on `/services`
- show the total host group count in the page header
- update the host groups view test to assert the rendered table structure and link output

## Why
The host groups index should match the simpler list presentation used for services and avoid carrying unused host-count data in the view model.

## Validation
- `cargo test test_view_authed_host_groups --lib`
- `cargo test test_unauthed_endpoints --lib`