### PR TITLE
Add Nagios-compatible check execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM debian:12 AS plugin_builder
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     build-essential \
+    dnsutils \
+    iputils-ping \
     pkg-config \
     procps \
     snmp
@@ -56,6 +58,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     dnsutils \
     git \
     iproute2 \
+    iputils-ping \
     python3 \
     python3-click \
     python3-venv \
@@ -70,7 +73,7 @@ COPY --from=cargo_builder /maremma/target/release/check_splunk /usr/local/bin/
 COPY --from=plugin_builder /maremma/plugins/libexec/* /usr/local/bin/
 COPY ./static /static/
 RUN for plugin in check_disk check_dns check_http check_load check_ping check_procs check_snmp check_ssh check_swap check_tcp check_users; do \
-        test -x "/usr/local/bin/${plugin}"; \
+        test -x "/usr/local/bin/${plugin}" || exit 1; \
     done
 RUN useradd maremma
 RUN chown -R maremma /static

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,12 +52,26 @@ FROM debian:12-slim AS maremma
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     ca-certificates \
-    snmp snmpd libsnmp-base && rm -rf /var/lib/apt/ /var/cache/apt/
+    curl \
+    dnsutils \
+    git \
+    iproute2 \
+    python3 \
+    python3-click \
+    python3-venv \
+    snmp snmpd libsnmp-base \
+    && python3 -m venv /opt/check_goodwe \
+    && /opt/check_goodwe/bin/pip install --no-cache-dir \
+        "git+https://github.com/yaleman/check_goodwe.git@d33d3357707e86826de64106f0617ec994260983" \
+    && rm -rf /var/lib/apt/ /var/cache/apt/
 
 COPY --from=cargo_builder /maremma/target/release/maremma /maremma
 COPY --from=cargo_builder /maremma/target/release/check_splunk /usr/local/bin/
 COPY --from=plugin_builder /maremma/plugins/libexec/* /usr/local/bin/
 COPY ./static /static/
+RUN for plugin in check_disk check_dns check_http check_load check_ping check_procs check_snmp check_ssh check_swap check_tcp check_users; do \
+        test -x "/usr/local/bin/${plugin}"; \
+    done
 RUN useradd maremma
 RUN chown -R maremma /static
 RUN chgrp -R maremma /static

--- a/maremma.schema.json
+++ b/maremma.schema.json
@@ -1,22 +1,13 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Configuration",
   "description": "The result of parsing the configuration file, don't instantiate this directly!",
   "type": "object",
-  "required": [
-    "cert_file",
-    "cert_key",
-    "frontend_url",
-    "hosts",
-    "max_history_entries_per_check",
-    "oidc_client_id",
-    "oidc_issuer"
-  ],
   "properties": {
     "database_file": {
       "description": "Path to the database file (or `:memory:` for in-memory)",
-      "default": "maremma.sqlite",
-      "type": "string"
+      "type": "string",
+      "default": "maremma.sqlite"
     },
     "static_path": {
       "description": "The path to the web server's static files, defaults to [crate::constants::WEB_SERVER_DEFAULT_STATIC_PATH]",
@@ -27,8 +18,8 @@
     },
     "listen_address": {
       "description": "The listen address, eg `0.0.0.0` or `127.0.0.1``",
-      "default": "127.0.0.1",
-      "type": "string"
+      "type": "string",
+      "default": "127.0.0.1"
     },
     "listen_port": {
       "description": "Defaults to 8888",
@@ -37,33 +28,30 @@
         "null"
       ],
       "format": "uint16",
-      "minimum": 1.0
+      "minimum": 1,
+      "maximum": 65535
     },
     "hosts": {
       "description": "Host configuration",
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/Host"
+        "$ref": "#/$defs/Host"
       }
     },
     "local_services": {
       "description": "Services to run locally",
+      "$ref": "#/$defs/FakeHost",
       "default": {
         "services": []
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/FakeHost"
-        }
-      ]
+      }
     },
     "services": {
       "description": "Service configuration",
-      "default": {},
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/Service"
-      }
+        "$ref": "#/$defs/Service"
+      },
+      "default": {}
     },
     "frontend_url": {
       "description": "The frontend URL ie `https://maremma.example.com` used for things like OIDC",
@@ -94,31 +82,36 @@
     },
     "max_concurrent_checks": {
       "description": "The maximum concurrent checks we'll run at one time",
-      "default": 10,
       "type": "integer",
       "format": "uint",
-      "minimum": 0.0
+      "minimum": 0,
+      "default": 46
     },
     "max_history_entries_per_check": {
       "description": "How many history entries to keep per check, defaults to 25000 ([crate::constants::DEFAULT_HISTORY_LIMIT]), setting this too high can cause slowdowns.",
       "type": "integer",
       "format": "uint64",
-      "minimum": 0.0
+      "minimum": 0
     }
   },
-  "definitions": {
+  "required": [
+    "hosts",
+    "frontend_url",
+    "oidc_issuer",
+    "oidc_client_id",
+    "cert_file",
+    "cert_key",
+    "max_history_entries_per_check"
+  ],
+  "$defs": {
     "Host": {
       "description": "A generic host",
       "type": "object",
       "properties": {
         "check": {
           "description": "The kind of check",
-          "default": "ping",
-          "allOf": [
-            {
-              "$ref": "#/definitions/HostCheck"
-            }
-          ]
+          "$ref": "#/$defs/HostCheck",
+          "default": "ping"
         },
         "hostname": {
           "description": "The hostname",
@@ -129,11 +122,11 @@
         },
         "host_groups": {
           "description": "Groups that this host is part of",
-          "default": [],
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "default": []
         },
         "config": {
           "description": "Extra configuration for services, the key matches the service name",
@@ -149,39 +142,28 @@
         {
           "description": "No checks done",
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "const": "none"
         },
         {
           "description": "Checks by pinging the host",
           "type": "string",
-          "enum": [
-            "ping"
-          ]
+          "const": "ping"
         },
         {
           "description": "Checks by trying to SSH to the host",
           "type": "string",
-          "enum": [
-            "ssh"
-          ]
+          "const": "ssh"
         },
         {
           "description": "Checks we can connect to the Kubernetes API",
           "type": "string",
-          "enum": [
-            "kubernetes"
-          ]
+          "const": "kubernetes"
         }
       ]
     },
     "FakeHost": {
       "description": "Used as part of local-only service checks",
       "type": "object",
-      "required": [
-        "services"
-      ],
       "properties": {
         "services": {
           "description": "Services on this host",
@@ -190,22 +172,20 @@
             "type": "string"
           }
         }
-      }
+      },
+      "required": [
+        "services"
+      ]
     },
     "Service": {
       "description": "Base service type",
       "type": "object",
-      "required": [
-        "cron_schedule",
-        "host_groups",
-        "service_type"
-      ],
       "properties": {
         "id": {
           "description": "The internal ID of the service, regenerated internally if not provided",
-          "default": "00000000-0000-0000-0000-000000000000",
           "type": "string",
-          "format": "uuid"
+          "format": "uuid",
+          "default": "00000000-0000-0000-0000-000000000000"
         },
         "name": {
           "description": "This is pulled from the config file's key",
@@ -230,17 +210,18 @@
         },
         "service_type": {
           "description": "What kind of service it is",
-          "allOf": [
-            {
-              "$ref": "#/definitions/ServiceType"
-            }
-          ]
+          "$ref": "#/$defs/ServiceType"
         },
         "cron_schedule": {
           "description": "Cron schedule for the service, eg `@hourly`, `* * * * * *` or `0 0 * * *`",
           "type": "string"
         }
       },
+      "required": [
+        "host_groups",
+        "service_type",
+        "cron_schedule"
+      ],
       "additionalProperties": true
     },
     "ServiceType": {
@@ -249,37 +230,32 @@
         {
           "description": "CLI service",
           "type": "string",
-          "enum": [
-            "cli"
-          ]
+          "const": "cli"
         },
         {
           "description": "SSH service",
           "type": "string",
-          "enum": [
-            "ssh"
-          ]
+          "const": "ssh"
         },
         {
           "description": "Ping service",
           "type": "string",
-          "enum": [
-            "ping"
-          ]
+          "const": "ping"
         },
         {
           "description": "HTTP service",
           "type": "string",
-          "enum": [
-            "http"
-          ]
+          "const": "http"
         },
         {
           "description": "TLS service",
           "type": "string",
-          "enum": [
-            "tls"
-          ]
+          "const": "tls"
+        },
+        {
+          "description": "Kubernetes service",
+          "type": "string",
+          "const": "kubernetes"
         }
       ]
     }

--- a/src/check_loop.rs
+++ b/src/check_loop.rs
@@ -346,8 +346,8 @@ pub async fn run_check_loop(
 mod tests {
     use entities::service_check;
     use opentelemetry::metrics::MeterProvider;
-    use sea_orm::{ActiveModelTrait, EntityTrait, QueryFilter, Set};
     use sea_orm::sea_query::Expr;
+    use sea_orm::{ActiveModelTrait, EntityTrait, QueryFilter, Set};
 
     use super::*;
     use crate::db::entities::{host, service};

--- a/src/db/entities/service.rs
+++ b/src/db/entities/service.rs
@@ -205,6 +205,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn kubernetes_service_type_round_trips_through_database() {
+        let (db, _config) = test_setup().await.expect("Failed to start test harness");
+        let service = Model {
+            id: Uuid::new_v4(),
+            name: "Kubernetes API".to_string(),
+            description: Some("Kubernetes API".to_string()),
+            service_type: ServiceType::Kubernetes,
+            cron_schedule: "*/10 * * * *".to_string(),
+            extra_config: json!({"check": "api_available", "jitter": 30}),
+        };
+
+        Entity::insert(service.clone().into_active_model())
+            .exec(db.as_ref())
+            .await
+            .expect("Failed to insert Kubernetes service");
+        let stored = Entity::find_by_id(service.id)
+            .one(db.as_ref())
+            .await
+            .expect("Failed to query Kubernetes service")
+            .expect("Kubernetes service was not stored");
+
+        assert_eq!(stored.service_type, ServiceType::Kubernetes);
+        assert_eq!(stored.extra_config["check"], "api_available");
+    }
+
+    #[tokio::test]
     async fn test_service_update_db_from_config() {
         let (db, _config) = test_setup().await.expect("Failed to start test harness");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,22 @@ async fn async_main(cli: CliOpts) -> Result<(), ExitCode> {
 
     let config = Arc::new(RwLock::new(config));
 
+    match &cli.action {
+        Actions::CheckConfig(_) => {
+            info!("Configuration is valid");
+            return Ok(());
+        }
+        Actions::ShowConfig(_) => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&*config.read().await)
+                    .unwrap_or(format!("Failed to serialize config: {:?}", config))
+            );
+            return Ok(());
+        }
+        _ => {}
+    }
+
     // in case we need it, get the connect string
     let connect_string = get_connect_string(config.clone()).await;
     let db = Arc::new(maremma::db::connect(config.clone()).await.map_err(|err| {
@@ -118,16 +134,7 @@ async fn async_main(cli: CliOpts) -> Result<(), ExitCode> {
 
             }
         }
-        Actions::CheckConfig(_show_config) => {
-            todo!("Check config CLI hasn't been implemented")
-        }
-        Actions::ShowConfig(_show_config) => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&*config.read().await)
-                    .unwrap_or(format!("Failed to serialize config: {:?}", config))
-            );
-        }
+        Actions::CheckConfig(_) | Actions::ShowConfig(_) => unreachable!(),
         Actions::OneShot(cmd) => match run_oneshot(cmd, config).await {
             Err(maremma::errors::MaremmaError::OneShotFailed) => return Err(ExitCode::from(1)),
             Err(err) => error!("Failed to run oneshot: {:?}", err),

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,7 +8,9 @@ pub(crate) use crate::db::tests::test_setup;
 pub(crate) use crate::errors::MaremmaError;
 pub(crate) use crate::host::GenericHost;
 pub(crate) use crate::host::Host;
-pub(crate) use crate::services::{Service, ServiceStatus, ServiceTrait, ServiceType};
+pub(crate) use crate::services::{
+    MonitoringPluginExit, Service, ServiceStatus, ServiceTrait, ServiceType,
+};
 pub(crate) use crate::web::urls::Urls;
 pub(crate) use crate::LOCAL_SERVICE_HOST_NAME;
 pub(crate) use async_trait::async_trait;

--- a/src/services/cli.rs
+++ b/src/services/cli.rs
@@ -4,7 +4,6 @@ use schemars::JsonSchema;
 
 use super::prelude::*;
 use crate::prelude::*;
-use std::os::unix::process::ExitStatusExt;
 use std::process::Stdio;
 
 #[derive(Debug, Deserialize, Serialize, clap::Parser, JsonSchema)]
@@ -60,28 +59,33 @@ impl ServiceTrait for CliService {
 
         let command_line = config.command_line.replace("#HOSTNAME#", &hostname);
 
-        let mut cmd_split = command_line.split(" ");
-        let cmd = match cmd_split.next() {
-            Some(c) => c,
-            None => return Err(MaremmaError::Generic("No command specified!".to_string())),
+        let mut command = if config.run_in_shell {
+            let mut command = tokio::process::Command::new("/bin/sh");
+            command.arg("-c").arg(&command_line);
+            command
+        } else {
+            let mut cmd_split = command_line.split_whitespace();
+            let cmd = cmd_split
+                .next()
+                .ok_or_else(|| MaremmaError::InvalidInput("No command specified".to_string()))?;
+
+            let which_cmd = which::which(cmd).map_err(|err| {
+                MaremmaError::CommandNotFound(format!("Couldn't find {cmd}, error: {err}"))
+            })?;
+
+            if !which_cmd.exists() {
+                return Err(MaremmaError::CommandNotFound(format!(
+                    "Command not found: {}",
+                    which_cmd.display()
+                )));
+            }
+
+            let mut command = tokio::process::Command::new(which_cmd);
+            command.args(cmd_split);
+            command
         };
 
-        let which_cmd = which::which(cmd).map_err(|err| {
-            MaremmaError::CommandNotFound(format!("Couldn't find {}, error: {}", cmd, err))
-        })?;
-
-        if !which_cmd.exists() {
-            // check if the command exists
-            return Err(MaremmaError::CommandNotFound(format!(
-                "Command not found: {}",
-                which_cmd.display()
-            )));
-        }
-
-        let args = cmd_split.collect::<Vec<&str>>();
-
-        let child = tokio::process::Command::new(cmd)
-            .args(args)
+        let child = command
             .kill_on_drop(true)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -95,25 +99,16 @@ impl ServiceTrait for CliService {
 
         let time_elapsed = chrono::Utc::now() - start_time;
 
-        if res.status != std::process::ExitStatus::from_raw(0) {
-            let mut combined = res.stderr.to_vec();
-            combined.extend(res.stdout);
-            return Ok(CheckResult {
-                timestamp: Utc::now(),
-                result_text: String::from_utf8_lossy(&combined)
-                    .to_string()
-                    .replace(r#"\\n"#, " "),
-                status: ServiceStatus::Critical,
-                time_elapsed,
-            });
-        }
+        let mut combined = res.stdout;
+        combined.extend(res.stderr);
+        let status = MonitoringPluginExit::from(res.status.code()).into();
 
         Ok(CheckResult {
             timestamp: Utc::now(),
-            result_text: String::from_utf8_lossy(&res.stdout)
+            result_text: String::from_utf8_lossy(&combined)
                 .to_string()
                 .replace(r#"\\n"#, " "),
-            status: ServiceStatus::Ok,
+            status,
             time_elapsed,
         })
     }
@@ -153,6 +148,47 @@ mod tests {
         let res = service.run(&host).await;
         assert_eq!(service.name, "test".to_string());
         assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn shell_service_preserves_quoting_hostname_and_warning_status() {
+        let service = super::CliService {
+            name: "shell".to_string(),
+            hostname: None,
+            command_line: "printf '%s' '#HOSTNAME# quoted value'; exit 1".to_string(),
+            run_in_shell: true,
+            cron_schedule: "@hourly".parse().expect("Failed to parse cron schedule"),
+            jitter: None,
+        };
+        let host = entities::host::Model {
+            check: crate::host::HostCheck::None,
+            ..test_host()
+        };
+
+        let result = service.run(&host).await.expect("Shell check failed to run");
+        assert_eq!(result.status, ServiceStatus::Warning);
+        assert_eq!(result.result_text, "test_host_hostname quoted value");
+    }
+
+    #[tokio::test]
+    async fn shell_service_preserves_stdout_stderr_and_performance_data() {
+        let service = super::CliService {
+            name: "shell-output".to_string(),
+            hostname: None,
+            command_line: "printf 'CRITICAL | value=7'; printf ' diagnostic' >&2; exit 2"
+                .to_string(),
+            run_in_shell: true,
+            cron_schedule: "@hourly".parse().expect("Failed to parse cron schedule"),
+            jitter: None,
+        };
+
+        let result = service
+            .run(&test_host())
+            .await
+            .expect("Shell check failed to run");
+
+        assert_eq!(result.status, ServiceStatus::Critical);
+        assert_eq!(result.result_text, "CRITICAL | value=7 diagnostic");
     }
 
     #[test]

--- a/src/services/http.rs
+++ b/src/services/http.rs
@@ -89,6 +89,9 @@ pub struct HttpService {
     /// Name of the check
     pub name: String,
 
+    /// Hostname used for the request URL and TLS server name. Defaults to the target host address.
+    pub hostname: Option<String>,
+
     #[serde(with = "crate::serde::cron")]
     #[schemars(with = "String")]
     /// Cron schedule for the service
@@ -195,6 +198,7 @@ async fn test_overlay_host_config() {
 
     let service = HttpService {
         name: "test".to_string(),
+        hostname: None,
         cron_schedule: std::str::FromStr::from_str("@hourly").expect("Failed to parse @hourly"),
         http_method: HttpMethod::Get,
         http_uri: None,
@@ -256,6 +260,7 @@ impl ConfigOverlay for HttpService {
 
         Ok(Box::new(Self {
             name,
+            hostname: self.extract_value(value, "hostname", &self.hostname)?,
             cron_schedule: self.extract_cron(value, "cron_schedule", &self.cron_schedule)?,
             http_method: self.extract_value(value, "http_method", &self.http_method)?,
             http_uri: self.extract_value(value, "http_uri", &self.http_uri)?,
@@ -298,10 +303,12 @@ impl ServiceTrait for HttpService {
             "https"
         };
 
+        let hostname = config.hostname.as_ref().unwrap_or(&host.hostname);
+
         let url = format!(
             "{}://{}{}{}",
             scheme,
-            host.hostname,
+            hostname,
             config
                 .port
                 .map(|p| format!(":{p}"))
@@ -422,6 +429,7 @@ mod tests {
 
         let service = super::HttpService {
             name: "test".to_string(),
+            hostname: None,
             cron_schedule: "@hourly".parse().expect("Failed to parse cron schedule"),
             http_method: crate::services::http::HttpMethod::Get,
             validate_tls: false,
@@ -476,6 +484,7 @@ mod tests {
 
         let service = super::HttpService {
             name: "test".to_string(),
+            hostname: None,
             cron_schedule: "@hourly".parse().expect("Failed to parse cron schedule"),
             http_method: crate::services::http::HttpMethod::Get,
             http_uri: Some(Urls::Index.to_string()),
@@ -540,6 +549,7 @@ mod tests {
 
         let service = super::HttpService {
             name: "test".to_string(),
+            hostname: None,
             cron_schedule: "@hourly".parse().expect("Failed to parse cron schedule"),
             http_status: Some(NonZeroU16::new(301).expect("failed to parse 301 as non-zero u16")),
             http_method: HttpMethod::Get,
@@ -602,6 +612,7 @@ mod tests {
 
         let service = super::HttpService {
             name: "localhost".to_string(),
+            hostname: None,
             cron_schedule: "@hourly".parse().expect("Failed to parse cron schedule"),
             http_method: crate::services::http::HttpMethod::Get,
             http_uri: None,
@@ -640,6 +651,7 @@ mod tests {
 
         let service = super::HttpService {
             name: "localhost".to_string(),
+            hostname: None,
             cron_schedule: "@hourly".parse().expect("Failed to parse cron schedule"),
             http_method: crate::services::http::HttpMethod::Get,
             http_uri: None,
@@ -670,6 +682,7 @@ mod tests {
 
         let service = super::HttpService {
             name: "test".to_string(),
+            hostname: None,
             cron_schedule: "@hourly".parse().expect("Failed to parse cron schedule"),
             http_method: crate::services::http::HttpMethod::Get,
             http_uri: None,
@@ -772,6 +785,7 @@ mod tests {
 
         let service = HttpService {
             name: "test".to_string(),
+            hostname: None,
             cron_schedule: "@hourly".parse().expect("Failed to parse cron schedule"),
             http_method: HttpMethod::Get,
             http_uri: None,

--- a/src/services/http.rs
+++ b/src/services/http.rs
@@ -121,6 +121,9 @@ pub struct HttpService {
     /// Ensure the body has a certain string
     pub contains_string: Option<String>,
 
+    /// Ensure the response headers contain a case-insensitive string
+    pub contains_header: Option<String>,
+
     /// CA cert file to use
     pub ca_file: Option<PathBuf>,
 
@@ -170,6 +173,20 @@ impl HttpService {
             ));
         };
 
+        if let Some(expected_header) = client_config.contains_header.as_ref() {
+            let expected_header = expected_header.to_ascii_lowercase();
+            let header_found = response.headers().iter().any(|(name, value)| {
+                let header = format!("{name}: {}", String::from_utf8_lossy(value.as_bytes()));
+                header.to_ascii_lowercase().contains(&expected_header)
+            });
+            if !header_found {
+                return Ok((
+                    format!("Expected header string '{expected_header}' not found"),
+                    ServiceStatus::Critical,
+                ));
+            }
+        }
+
         let mut body: String = String::new();
 
         // if we're looking for a string, we need to read the body and check for it
@@ -208,6 +225,7 @@ async fn test_overlay_host_config() {
         port: None,
         use_http: None,
         contains_string: None,
+        contains_header: None,
         ca_file: None,
         jitter: None,
     };
@@ -269,6 +287,7 @@ impl ConfigOverlay for HttpService {
             connect_timeout: self.extract_value(value, "connect_timeout", &self.connect_timeout)?,
             port: self.extract_value(value, "port", &self.port)?,
             contains_string: self.extract_value(value, "contains_string", &self.contains_string)?,
+            contains_header: self.extract_value(value, "contains_header", &self.contains_header)?,
             ca_file: self.extract_value(value, "ca_file", &self.ca_file)?,
             use_http: self.extract_value(value, "use_http", &self.use_http)?,
             jitter: self.extract_value(value, "jitter", &self.jitter)?,
@@ -437,6 +456,7 @@ mod tests {
             port: Some(NonZeroU16::new(test_server.port).expect("Failed to parse local test port")),
             http_uri: None,
             contains_string: None,
+            contains_header: None,
             http_status: None,
             ca_file: None,
             jitter: None,
@@ -464,6 +484,53 @@ mod tests {
             }
         })
         .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_response_contains_header() {
+        let test_server = spawn_http_server(Router::new().route(
+            "/",
+            get(|| async {
+                (
+                    AxumStatusCode::OK,
+                    [("X-Frame-Options", "SAMEORIGIN")],
+                    Body::empty(),
+                )
+                    .into_response()
+            }),
+        ))
+        .await;
+
+        let mut service = super::HttpService {
+            name: "test".to_string(),
+            hostname: None,
+            cron_schedule: "@hourly".parse().expect("Failed to parse cron schedule"),
+            http_method: HttpMethod::Get,
+            http_uri: None,
+            http_status: None,
+            validate_tls: false,
+            connect_timeout: Some(5),
+            port: Some(NonZeroU16::new(test_server.port).expect("Failed to parse local test port")),
+            contains_string: None,
+            contains_header: Some("x-frame-options".to_string()),
+            ca_file: None,
+            use_http: Some(true),
+            jitter: None,
+        };
+        let host = entities::host::Model {
+            id: Uuid::new_v4(),
+            name: "test".to_string(),
+            hostname: "127.0.0.1".to_string(),
+            check: crate::host::HostCheck::None,
+            config: json!({}),
+        };
+
+        let result = service.run(&host).await.expect("HTTP check failed");
+        assert_eq!(result.status, ServiceStatus::Ok);
+
+        service.contains_header = Some("missing-header".to_string());
+        let result = service.run(&host).await.expect("HTTP check failed");
+        assert_eq!(result.status, ServiceStatus::Critical);
     }
 
     #[tokio::test]
@@ -495,6 +562,7 @@ mod tests {
                 NonZeroU16::new(test_container.published_port).expect("Failed to parse port"),
             ),
             contains_string: Some("Welcome to nginx!".to_string()),
+            contains_header: None,
             ca_file: Some(PathBuf::from(certs.ca_file.as_ref())),
             jitter: None,
             use_http: None,
@@ -558,6 +626,7 @@ mod tests {
             connect_timeout: None,
             port: Some(NonZeroU16::new(test_server.port).expect("Failed to parse local test port")),
             contains_string: None,
+            contains_header: None,
             ca_file: None,
             jitter: None,
             use_http: Some(true),
@@ -621,6 +690,7 @@ mod tests {
             connect_timeout: Some(15),
             port: NonZeroU16::new(test_container.published_port),
             contains_string: None,
+            contains_header: None,
             ca_file: None,
             jitter: None,
             use_http: None,
@@ -660,6 +730,7 @@ mod tests {
             connect_timeout: Some(15),
             port: NonZeroU16::new(test_container.published_port),
             contains_string: None,
+            contains_header: None,
             ca_file: None,
             jitter: None,
             use_http: None,
@@ -691,6 +762,7 @@ mod tests {
             connect_timeout: Some(5),
             port: None,
             contains_string: None,
+            contains_header: None,
             ca_file: None,
             jitter: None,
             use_http: None,
@@ -794,6 +866,7 @@ mod tests {
             connect_timeout: Some(5),
             port: None,
             contains_string: None,
+            contains_header: None,
             ca_file: None,
             jitter: None,
             use_http: None,

--- a/src/services/kubernetes.rs
+++ b/src/services/kubernetes.rs
@@ -1,63 +1,125 @@
-//! Kubernetes service
+//! Kubernetes service checks.
 
-use kube::Client;
+use k8s_openapi::api::core::v1::Pod;
+use kube::{Api, Client};
+use schemars::JsonSchema;
 
 use super::prelude::*;
 use crate::prelude::*;
 
+#[derive(Debug, Default, Deserialize, JsonSchema, Serialize, Copy, Clone, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+/// The Kubernetes operation performed by a service check.
+pub enum KubernetesCheck {
+    /// Confirm that the API server responds to a version request.
+    #[default]
+    ApiAvailable,
+    /// Report pods that are neither running nor completed successfully.
+    UnhealthyPods,
+}
+
 #[derive(Debug, Deserialize, JsonSchema, Serialize)]
-/// KubernetesService is a service that checks the availability of a Kubernetes cluster
+/// A service that checks a Kubernetes cluster using the configured kube client.
 pub struct KubernetesService {
-    /// Name of the service
+    /// Name of the service.
     pub name: String,
-    /// Host to check
-    pub host: Host,
+    /// The Kubernetes operation to perform.
+    #[serde(default)]
+    pub check: KubernetesCheck,
     #[serde(with = "crate::serde::cron")]
-    /// The cron schedule for this service
     #[schemars(with = "String")]
+    /// Schedule for the service.
     pub cron_schedule: Cron,
-    /// Add random jitter in 0..n seconds to the check
+    /// Add random jitter in 0..n seconds to the check.
     pub jitter: Option<u16>,
 }
 
 impl ConfigOverlay for KubernetesService {
     fn overlay_host_config(&self, value: &Map<String, Json>) -> Result<Box<Self>, MaremmaError> {
-        let name = self.extract_string(value, "name", &self.name);
-        let cron_schedule = self.extract_cron(value, "cron_schedule", &self.cron_schedule)?;
-
         Ok(Box::new(Self {
-            name,
-            cron_schedule,
-            host: self.extract_value(value, "host", &self.host)?,
+            name: self.extract_string(value, "name", &self.name),
+            check: self.extract_value(value, "check", &self.check)?,
+            cron_schedule: self.extract_cron(value, "cron_schedule", &self.cron_schedule)?,
             jitter: self.extract_value(value, "jitter", &self.jitter)?,
         }))
+    }
+}
+
+fn unhealthy_pods(pods: &[Pod]) -> Vec<String> {
+    pods.iter()
+        .filter_map(|pod| {
+            let phase = pod
+                .status
+                .as_ref()
+                .and_then(|status| status.phase.as_deref());
+            if matches!(phase, Some("Running" | "Succeeded")) {
+                return None;
+            }
+
+            let namespace = pod.metadata.namespace.as_deref().unwrap_or("default");
+            let name = pod.metadata.name.as_deref().unwrap_or("unknown");
+            Some(format!("{namespace}/{name}={}", phase.unwrap_or("Unknown")))
+        })
+        .collect()
+}
+
+impl KubernetesService {
+    async fn run_check(&self, client: Client) -> (String, ServiceStatus) {
+        match self.check {
+            KubernetesCheck::ApiAvailable => match client.apiserver_version().await {
+                Ok(version) => (
+                    format!("OK: Kubernetes {}", version.git_version),
+                    ServiceStatus::Ok,
+                ),
+                Err(err) => (format!("CRITICAL: {err}"), ServiceStatus::Critical),
+            },
+            KubernetesCheck::UnhealthyPods => {
+                let pods: Api<Pod> = Api::all(client);
+                match pods.list(&Default::default()).await {
+                    Ok(pods) => {
+                        let unhealthy = unhealthy_pods(&pods.items);
+                        if unhealthy.is_empty() {
+                            (
+                                "OK: All pods are running or succeeded".to_string(),
+                                ServiceStatus::Ok,
+                            )
+                        } else {
+                            (
+                                format!(
+                                    "CRITICAL: {} pods are not running or succeeded {}",
+                                    unhealthy.len(),
+                                    unhealthy.join(" ")
+                                ),
+                                ServiceStatus::Critical,
+                            )
+                        }
+                    }
+                    Err(err) => (format!("CRITICAL: {err}"), ServiceStatus::Critical),
+                }
+            }
+        }
     }
 }
 
 #[async_trait]
 impl ServiceTrait for KubernetesService {
     async fn run(&self, host: &entities::host::Model) -> Result<CheckResult, MaremmaError> {
-        let start_time: DateTime<Utc> = chrono::Utc::now();
-
-        let _config = self.overlay_host_config(&self.get_host_config(&self.name, host)?)?;
+        let start_time = Utc::now();
+        let config = self.overlay_host_config(&self.get_host_config(&self.name, host)?)?;
 
         let client = match Client::try_default().await {
-            Ok(val) => val,
+            Ok(client) => client,
             Err(err) => {
                 return Ok(CheckResult {
                     timestamp: start_time,
                     result_text: format!("UNKNOWN: Unable to configure Kubernetes client: {err}"),
                     status: ServiceStatus::Unknown,
                     time_elapsed: Utc::now() - start_time,
-                })
+                });
             }
         };
 
-        let (result_text, status) = match client.apiserver_version().await {
-            Ok(_) => ("OK".to_string(), ServiceStatus::Ok),
-            Err(err) => (format!("CRITICAL: {err}"), ServiceStatus::Critical),
-        };
-
+        let (result_text, status) = config.run_check(client).await;
         Ok(CheckResult {
             timestamp: start_time,
             result_text,
@@ -78,53 +140,55 @@ impl ServiceTrait for KubernetesService {
 
 #[cfg(test)]
 mod tests {
-    use entities::host::test_host;
-
-    use crate::db::tests::test_setup;
-    use crate::host::kube::KubeHost;
-
     use super::*;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 
-    #[tokio::test]
-    async fn test_kubernetes_service() {
-        let _ = test_setup().await.expect("Failed to set up test env");
+    fn pod(name: &str, namespace: &str, phase: Option<&str>) -> Pod {
+        Pod {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(namespace.to_string()),
+                ..Default::default()
+            },
+            status: Some(k8s_openapi::api::core::v1::PodStatus {
+                phase: phase.map(str::to_string),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
 
-        let hostname = match std::env::var("MAREMMA_TEST_KUBE_HOST") {
-            Ok(val) => val,
-            Err(_) => {
-                eprintln!("MAREMMA_TEST_KUBE_HOST not set, skipping test");
-                return;
-            }
-        };
+    #[test]
+    fn filters_running_and_succeeded_pods() {
+        let pods = vec![
+            pod("running", "default", Some("Running")),
+            pod("job", "jobs", Some("Succeeded")),
+            pod("broken", "default", Some("CrashLoopBackOff")),
+            pod("pending", "apps", Some("Pending")),
+            pod("unknown", "apps", None),
+        ];
 
-        let host = Host {
-            check: crate::host::HostCheck::Kubernetes,
-            hostname: Some(hostname.clone()),
-            ..test_host().into()
-        };
-        let kubehost = KubeHost::try_from(&host).expect("Failed to convert host to kubehost");
-        kubehost
-            .check_up()
-            .await
-            .expect("Failed to check_up kubehost");
+        assert_eq!(
+            unhealthy_pods(&pods),
+            vec![
+                "default/broken=CrashLoopBackOff",
+                "apps/pending=Pending",
+                "apps/unknown=Unknown",
+            ]
+        );
+    }
 
-        let service = KubernetesService {
-            name: "kubernetes".to_string(),
-            host,
-            cron_schedule: std::str::FromStr::from_str("0 0 * * *").expect("Failed to parse cron"),
-            jitter: None,
-        };
+    #[test]
+    fn parses_public_service_configuration() {
+        let value = json!({
+            "name": "pods",
+            "service_type": "kubernetes",
+            "host_groups": ["k8s_leader"],
+            "check": "unhealthy_pods",
+            "cron_schedule": "*/10 * * * *"
+        });
 
-        let result = service
-            .run(&entities::host::Model {
-                id: Uuid::new_v4(),
-                name: "test host".to_string(),
-                hostname,
-                check: crate::host::HostCheck::None,
-                config: json!({}),
-            })
-            .await
-            .expect("Failed to run");
-        assert!(result.status == ServiceStatus::Ok || result.status == ServiceStatus::Critical);
+        let service = Service::try_from(&value).expect("Failed to parse Kubernetes service");
+        assert_eq!(service.service_type, ServiceType::Kubernetes);
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -69,6 +69,45 @@ pub enum ServiceStatus {
     Disabled,
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+/// The standard exit states returned by monitoring plugins.
+pub enum MonitoringPluginExit {
+    /// Exit code 0.
+    Ok,
+    /// Exit code 1.
+    Warning,
+    /// Exit code 2.
+    Critical,
+    /// Exit code 3.
+    Unknown,
+    /// The process exited with a non-standard code or was terminated by a signal.
+    Error(Option<i32>),
+}
+
+impl From<Option<i32>> for MonitoringPluginExit {
+    fn from(value: Option<i32>) -> Self {
+        match value {
+            Some(0) => Self::Ok,
+            Some(1) => Self::Warning,
+            Some(2) => Self::Critical,
+            Some(3) => Self::Unknown,
+            value => Self::Error(value),
+        }
+    }
+}
+
+impl From<MonitoringPluginExit> for ServiceStatus {
+    fn from(value: MonitoringPluginExit) -> Self {
+        match value {
+            MonitoringPluginExit::Ok => Self::Ok,
+            MonitoringPluginExit::Warning => Self::Warning,
+            MonitoringPluginExit::Critical => Self::Critical,
+            MonitoringPluginExit::Unknown => Self::Unknown,
+            MonitoringPluginExit::Error(_) => Self::Error,
+        }
+    }
+}
+
 impl From<ServiceStatus> for i8 {
     fn from(value: ServiceStatus) -> i8 {
         match value {
@@ -311,6 +350,10 @@ pub(crate) fn service_config_parse(
             tls::TlsService::from_config(value)
                 .inspect_err(|_| error!("Failed to parse config for {}", service_identifier))?,
         ) as Box<dyn ServiceTrait>,
+        ServiceType::Kubernetes => Box::new(
+            kubernetes::KubernetesService::from_config(value)
+                .inspect_err(|_| error!("Failed to parse config for {}", service_identifier))?,
+        ) as Box<dyn ServiceTrait>,
     };
 
     res.validate()?;
@@ -424,7 +467,7 @@ impl Service {
     ValueEnum,
 )]
 #[serde(rename_all = "lowercase")]
-#[sea_orm(rs_type = "String", db_type = "String(StringLen::N(5))")]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::N(10))")]
 /// The type of service
 pub enum ServiceType {
     /// CLI service
@@ -442,6 +485,9 @@ pub enum ServiceType {
     /// TLS service
     #[sea_orm(string_value = "tls")]
     Tls,
+    /// Kubernetes service
+    #[sea_orm(string_value = "kubernetes")]
+    Kubernetes,
 }
 
 impl Display for ServiceType {
@@ -452,6 +498,7 @@ impl Display for ServiceType {
             Self::Ping => write!(f, "Ping"),
             Self::Http => write!(f, "HTTP"),
             Self::Tls => write!(f, "TLS"),
+            Self::Kubernetes => write!(f, "Kubernetes"),
         }
     }
 }
@@ -555,6 +602,24 @@ mod tests {
         assert_eq!(format!("{}", ServiceType::Ping), "Ping");
         assert_eq!(format!("{}", ServiceType::Http), "HTTP");
         assert_eq!(format!("{}", ServiceType::Tls), "TLS");
+        assert_eq!(format!("{}", ServiceType::Kubernetes), "Kubernetes");
+    }
+
+    #[test]
+    fn monitoring_plugin_exit_codes_preserve_status() {
+        for (code, expected) in [
+            (Some(0), ServiceStatus::Ok),
+            (Some(1), ServiceStatus::Warning),
+            (Some(2), ServiceStatus::Critical),
+            (Some(3), ServiceStatus::Unknown),
+            (Some(4), ServiceStatus::Error),
+            (None, ServiceStatus::Error),
+        ] {
+            assert_eq!(
+                ServiceStatus::from(MonitoringPluginExit::from(code)),
+                expected
+            );
+        }
     }
 
     #[test]

--- a/src/services/oneshot.rs
+++ b/src/services/oneshot.rs
@@ -6,6 +6,7 @@ use crate::cli::OneShotCmd;
 use crate::prelude::*;
 use crate::services::cli::CliService;
 use crate::services::http::HttpService;
+use crate::services::kubernetes::KubernetesService;
 use crate::services::ping::PingService;
 use crate::services::service_config_parse;
 use crate::services::ssh::SshService;
@@ -25,6 +26,7 @@ fn export_config(cmd: &OneShotCmd) -> (String, String) {
         ServiceType::Ping => schema_for!(PingService),
         ServiceType::Http => schema_for!(HttpService),
         ServiceType::Tls => schema_for!(TlsService),
+        ServiceType::Kubernetes => schema_for!(KubernetesService),
     };
     (
         format!("Dumping schema for {:?}", cmd.check),

--- a/src/services/ssh.rs
+++ b/src/services/ssh.rs
@@ -163,9 +163,10 @@ impl ServiceTrait for SshService {
 
         let time_elapsed = chrono::Utc::now() - start_time;
 
-        let status = match exit_status == config.exit_code.unwrap_or(0) {
-            false => ServiceStatus::Critical,
-            true => ServiceStatus::Ok,
+        let status = match config.exit_code {
+            Some(expected) if exit_status == expected => ServiceStatus::Ok,
+            Some(_) => ServiceStatus::Critical,
+            None => MonitoringPluginExit::from(i32::try_from(exit_status).ok()).into(),
         };
 
         Ok(CheckResult {

--- a/src/services/tls/mod.rs
+++ b/src/services/tls/mod.rs
@@ -32,6 +32,8 @@ pub struct TlsService {
     // TODO: sni/hostname to check
     /// Name of the service
     pub name: String,
+    /// Hostname used for the TCP connection and TLS server name. Defaults to the target host address.
+    pub hostname: Option<String>,
     #[serde(with = "crate::serde::cron")]
     #[schemars(with = "String")]
     /// Schedule to run the check on
@@ -56,6 +58,7 @@ impl ConfigOverlay for TlsService {
     fn overlay_host_config(&self, value: &Map<String, Json>) -> Result<Box<Self>, MaremmaError> {
         Ok(Box::new(Self {
             name: self.extract_string(value, "name", &self.name),
+            hostname: self.extract_value(value, "hostname", &self.hostname)?,
             cron_schedule: self.extract_cron(value, "cron_schedule", &self.cron_schedule)?,
             port: self.extract_value(value, "port", &self.port)?,
             expiry_critical: self.extract_value(value, "expiry_critical", &self.expiry_critical)?,
@@ -74,6 +77,7 @@ impl ServiceTrait for TlsService {
     timeout=self.timeout))]
     async fn run(&self, host: &entities::host::Model) -> Result<CheckResult, MaremmaError> {
         let start_time = chrono::Utc::now();
+        let config = self.overlay_host_config(&self.get_host_config(&self.name, host)?)?;
 
         // this comes from the rustls example here: https://github.com/rustls/tokio-rustls/blob/HEAD/examples/client.rs
         let root_store = RootCertStore {
@@ -91,27 +95,29 @@ impl ServiceTrait for TlsService {
             .set_certificate_verifier(tls_verifier);
 
         let connector = TlsConnector::from(Arc::new(client_config));
-        let dnsname = match ServerName::try_from(host.hostname.clone()) {
+        let hostname = config.hostname.as_ref().unwrap_or(&host.hostname).clone();
+        let dnsname = match ServerName::try_from(hostname.clone()) {
             Ok(val) => val,
             Err(_err) => {
                 debug!(
                     "Invalid hostname specified for TLS check hostname={}",
-                    host.hostname
+                    hostname
                 );
                 let timestamp = chrono::Utc::now();
                 return Ok(CheckResult {
                     time_elapsed: start_time - timestamp,
                     timestamp: Utc::now(),
                     status: ServiceStatus::Critical,
-                    result_text: format!("Invalid hostname '{}'", host.hostname),
+                    result_text: format!("Invalid hostname '{hostname}'"),
                 });
             }
         };
 
-        let timeout_duration = tokio::time::Duration::from_secs(self.timeout.unwrap_or(10) as u64);
+        let timeout_duration =
+            tokio::time::Duration::from_secs(config.timeout.unwrap_or(10) as u64);
         let stream = match tokio::time::timeout(
             timeout_duration,
-            TcpStream::connect(format!("{}:{}", host.hostname, self.port)),
+            TcpStream::connect(format!("{}:{}", hostname, config.port)),
         )
         .await
         {
@@ -120,7 +126,7 @@ impl ServiceTrait for TlsService {
                 Err(err) => {
                     debug!(
                         "Failed to TcpStream::connect to hostname=\"{}\" error=\"{}\"",
-                        host.hostname, err
+                        hostname, err
                     );
                     let timestamp = chrono::Utc::now();
                     return Ok(CheckResult {
@@ -129,7 +135,7 @@ impl ServiceTrait for TlsService {
                         status: ServiceStatus::Critical,
                         result_text: format!(
                             "Failed to connect to hostname=\"{}\" error=\"{}\"",
-                            host.hostname, err
+                            hostname, err
                         ),
                     });
                 }
@@ -161,8 +167,8 @@ impl ServiceTrait for TlsService {
         let mut result_strings = Vec::new();
 
         let expiry_critical_seconds =
-            self.expiry_critical.unwrap_or(DEFAULT_CRITICAL_DAYS) as i64 * 86400;
-        let expiry_warn_seconds = self.expiry_warn.unwrap_or(DEFAULT_WARNING_DAYS) as i64 * 86400;
+            config.expiry_critical.unwrap_or(DEFAULT_CRITICAL_DAYS) as i64 * 86400;
+        let expiry_warn_seconds = config.expiry_warn.unwrap_or(DEFAULT_WARNING_DAYS) as i64 * 86400;
 
         if result.cert_expired() {
             status = ServiceStatus::Critical;

--- a/src/services/tls/tests.rs
+++ b/src/services/tls/tests.rs
@@ -32,6 +32,7 @@ async fn test_working_tls_service() {
 
     let service = crate::services::tls::TlsService {
         name: "test".to_string(),
+        hostname: None,
         cron_schedule: "0 0 * * * * *".parse().expect("Failed to parse cron"),
         port: test_container
             .published_port
@@ -81,6 +82,7 @@ async fn test_expired_tls_service() {
 
     let service = crate::services::tls::TlsService {
         name: "localhost".to_string(),
+        hostname: None,
         cron_schedule: "0 0 * * * * *".parse().expect("Failed to parse cron"),
         port: test_container
             .published_port
@@ -335,6 +337,7 @@ async fn test_service_parser() {
         extra_config,
         config: Some(Box::new(TlsService {
             name: "tls_service".to_string(),
+            hostname: None,
             cron_schedule: croner::Cron::from_str("* * * * *").expect("Failed to parse cron"),
             port: 1234.try_into().expect("Failed to convert port"),
             expiry_critical: Some(1),
@@ -370,6 +373,7 @@ fn test_failed_service_parser() {
         extra_config: std::collections::HashMap::new(),
         config: Some(Box::new(TlsService {
             name: "tls_service".to_string(),
+            hostname: None,
             cron_schedule: croner::Cron::from_str("* * * * *").expect("Failed to parse cron"),
             port: 1234.try_into().expect("Failed to convert port"),
             expiry_critical: Some(1),

--- a/src/tests/tls_utils.rs
+++ b/src/tests/tls_utils.rs
@@ -302,9 +302,9 @@ pub(crate) fn load_ca(
         error!(err = ?e, "Failed to convert PEM to key");
     })?;
 
-        check_privkey_minimums(&ca_key).map_err(|err| {
-            debug!("{}", err);
-        })?;
+    check_privkey_minimums(&ca_key).map_err(|err| {
+        debug!("{}", err);
+    })?;
 
     let ca_cert = X509::from_pem(&ca_cert_pem).map_err(|e| {
         error!(err = ?e, "Failed to convert PEM to cert");

--- a/tests/check_config.rs
+++ b/tests/check_config.rs
@@ -1,0 +1,71 @@
+use std::process::Command;
+
+#[test]
+fn valid_configuration_does_not_create_database() {
+    let tempdir = tempfile::tempdir().expect("Failed to create temporary directory");
+    let config_path = tempdir.path().join("maremma.json");
+    let database_path = tempdir.path().join("must-not-exist.sqlite");
+    let config = serde_json::json!({
+        "database_file": database_path,
+        "hosts": {},
+        "services": {},
+        "frontend_url": "https://maremma.example.test",
+        "oidc_issuer": "https://idm.example.test/oauth2/openid/maremma",
+        "oidc_client_id": "maremma",
+        "cert_file": "",
+        "cert_key": "",
+        "max_history_entries_per_check": 10
+    });
+    std::fs::write(
+        &config_path,
+        serde_json::to_vec(&config).expect("Failed to serialize configuration"),
+    )
+    .expect("Failed to write configuration");
+
+    let result = Command::new(env!("CARGO_BIN_EXE_maremma"))
+        .args(["check-config", "--config"])
+        .arg(&config_path)
+        .status()
+        .expect("Failed to run maremma check-config");
+
+    assert!(result.success());
+    assert!(!database_path.exists());
+}
+
+#[test]
+fn invalid_configuration_returns_failure_without_creating_database() {
+    let tempdir = tempfile::tempdir().expect("Failed to create temporary directory");
+    let config_path = tempdir.path().join("maremma.json");
+    let database_path = tempdir.path().join("must-not-exist.sqlite");
+    let config = serde_json::json!({
+        "database_file": database_path,
+        "hosts": {},
+        "services": {
+            "invalid": {
+                "service_type": "not-a-service",
+                "host_groups": [],
+                "cron_schedule": "@hourly"
+            }
+        },
+        "frontend_url": "https://maremma.example.test",
+        "oidc_issuer": "https://idm.example.test/oauth2/openid/maremma",
+        "oidc_client_id": "maremma",
+        "cert_file": "",
+        "cert_key": "",
+        "max_history_entries_per_check": 10
+    });
+    std::fs::write(
+        &config_path,
+        serde_json::to_vec(&config).expect("Failed to serialize configuration"),
+    )
+    .expect("Failed to write configuration");
+
+    let result = Command::new(env!("CARGO_BIN_EXE_maremma"))
+        .args(["check-config", "--config"])
+        .arg(&config_path)
+        .status()
+        .expect("Failed to run maremma check-config");
+
+    assert!(!result.success());
+    assert!(!database_path.exists());
+}


### PR DESCRIPTION
## Summary

- Preserve monitoring-plugin exit semantics for CLI and SSH services, including stdout, stderr, and performance output.
- Add shell-backed CLI execution, Kubernetes API and unhealthy-pod checks, native HTTP response-header matching, and database-free `check-config`.
- Package the monitoring plugins and runtime DNS/ping tools required by the Nagios-to-Maremma parity configuration.

## Why

Maremma needs to run the existing Nagios check set without collapsing warning and unknown states, losing plugin output, or requiring Nagios-specific configuration at execution time.

## Validation

- `cargo fmt --all --check`
- `just check` (217 Rust tests plus integration and check-config tests)
- Multi-architecture image build for linux/amd64 and linux/arm64
- Published-image plugin audit and `check-config` execution without database creation

## Deployment note

The corresponding Ansible parity configuration is deliberately gated by SSH preflight. Four legacy targets do not yet authorize the canonical Kanidm monitoring identity, so no Maremma container recreation or Nagios/NRPE shutdown has occurred.